### PR TITLE
Add generic initializer to `SwiftUIPhone`

### DIFF
--- a/Sources/SwiftUIPhone/SwiftUIPhone.swift
+++ b/Sources/SwiftUIPhone/SwiftUIPhone.swift
@@ -11,9 +11,13 @@ public struct SwiftUIPhone: View {
     @SwiftUI.Environment(\.colorScheme) var colorScheme
     private let rootView: AnyView
     private var phoneImage: Image { colorScheme == .dark ? Image.phoneBlack : Image.phoneWhite }
-
-    public init(rootView: AnyView = AnyView(Text("This is the root view of my app"))) {
-        self.rootView = rootView
+    
+    public init<Content>(rootView: Content) where Content : View {
+        self.rootView = AnyView(rootView)
+    }
+    
+    public init() {
+        self.init(rootView: Text("This is the root view of my app"))
     }
     
     public var body: some View {


### PR DESCRIPTION
I modified the initializer to allow a generic view argument, which automatically wraps the content with `AnyView` inside the initializer, slightly simplifying initializing a new `SwiftUIView`. Since supplying a view conforming to `AnyView` is still an acceptable argument, this is not a source-breaking change.
I also added a second initializer that initializes the view to the default argument you supplied with the original initializer.

Thank you, really enjoy what you've done here!